### PR TITLE
Fix scope encoding

### DIFF
--- a/lib/omniauth/strategies/apple.rb
+++ b/lib/omniauth/strategies/apple.rb
@@ -46,6 +46,10 @@ module OmniAuth
         options[:redirect_uri] || (full_host + script_name + callback_path)
       end
 
+      def request_phase
+        redirect client.auth_code.authorize_url({:redirect_uri => callback_url}.merge(authorize_params)).gsub(/\+/, '%20')
+      end
+
       private
 
       def new_nonce


### PR DESCRIPTION
When providing both email and name as scopes. For example "email name" the request URL is being incorrectly transformed with a + between the scope names rather than correctly using a %20.

Incorrect: "name+email"
Correct: "name%20email"

@sebfie helpfully diagnosed the issue and figured out the fix here nhosoya#12 (comment)

I wondered if we could get this merged and released in the gem.

Closes nhosoya#12
Closes nhosoya#13

https://github.com/fdoxyz/omniauth-apple/pull/1/commits/366272af2ddabf1c9609d18e3e6cca0f594c020e